### PR TITLE
Fix Dates Issue For Review

### DIFF
--- a/gbmodel/model_sqlalchemy.py
+++ b/gbmodel/model_sqlalchemy.py
@@ -373,21 +373,19 @@ class capstone_session(db.Model):
 
             # check if final exists:
             if session.final_start is not None:
-                if date > session.final_start:
-
-                    # if after final period, return final
-                    if date > session.final_start:
-                        return 'final'
-                    elif session.midterm_start is not None:
-                        # otherwise if midterm exists, check if after midterm and return if so
-                        if date > session.midterm_start:
-                            return 'midterm'
-                    else:
-                        return 'Error'
+                # if after final period, return final
+                if date >= session.final_start:
+                    return 'final'
+                elif session.midterm_start is not None:
+                    # otherwise if midterm exists, check if after midterm and return if so
+                    if date >= session.midterm_start:
+                        return 'midterm'
+                else:
+                    return 'Error'
 
             elif session.midterm_start is not None:
                 # if only midterm exists, check midterm
-                if date > session.midterm_start:
+                if date >= session.midterm_start:
                     return 'midterm'
 
             else:


### PR DESCRIPTION
Fixes date checking for reviews, can now see a review on the first day

Testing:
To be safe, may want to check all of the below (did a quick check myself), but there's no code changes for these
Log in:
Dashboard:
shows score range?
Edit:
Prof Forms:
Report List:
Set/Add Date:
Automated Tests:

Reviews:
General review functionality will need to be tested as well as it correctly working with the capstone session dates:

To submit reviews:
go to .../review/
Currently this does not require log in.
In form.py there is a 'get id' method as a stand in for log in. Set this value to the id of the student you wish to review.
If a report is available and not filled out:
going to /review/ will display a form to be filled out. The names of all current team members should be displayed, along with entries like worth ethic, communication, etc. with radio buttons for each. Leadership, delegation, and organization should only be for the designated team lead.

Points are out of 100 across all team members. Only integer values should be accepted. The total should be 100. Give 0 to the reviewer.

Final should have a field at the end called something along the lines of 'are you proud of your accomplishment'. Midterm reviews should not have this.

All fields should need to be entered to submit successfully.

Checking reviews:
Through your preferred means (I recommend DB Browser for Sqllite) check the database to ensure that the appropriate forms were saved. If one form had an issue, none should be saved. If the reviews were saved, check the students table. The reviewer should have 'midterm_done' or 'final_done' marked as 1.

If the reviewer has already filled out the appropriate review (the _done field is 1), they should not be able to submit a review (you can go back after submitting a review and try submitting again) or access a review (aside from going back, try to access the review page again)

Determining Midterm, Final, or None:
The reports no longer use the 'active' attribute. Instead, available reviews are determined by the student's capstone session date.

Try out accessing reviews with: ---Remember to set the dates for the capstone session for the student(s) you are testing!---

-No dates set (should receive a message saying there are no open reviews)
-Only midterm set
----before midterm date(no open reviews)
----on midterm date (open review)
----after midterm date (available review)
-only final set
-----before final date (no open reviews)
-----on final date (open review)
-----after final date (open review)
-both midterm and final set
-----before midterm date (no open review)
-----on midterm date (midterm review)
------after midterm date (midterm review)
-----on final date (final review)
-----after final date(final review)