### PR TITLE
fix 'proud' label on review page

### DIFF
--- a/templates/review.html
+++ b/templates/review.html
@@ -152,8 +152,8 @@
         {%- endif %}
         {% if state == 'final' -%}
         <br>
+	<label for="proud">Are you proud of your accomplishment for this project?</label>
         {% if is_done == 1 -%}
-        <label for="proud">Are you proud of your accomplishment for this project?</label>
         <textarea placeholder="Are you proud of your accomplishment for this project?" class="form-control" name="proud" id="proud" required>
         {% for k in data -%}
         {% if k['proud'] is defined -%}{{k['proud']}}{%- endif %}


### PR DESCRIPTION
fix for missing label for "are you proud of your accomplishment" on a fresh final review.
no python changes

how to test:
go through the process of getting to a new final review

do you see a label for 'Are you proud of your accomplishment for this project?' at the bottom.

After submitting, try editing your review. Do you still see the label?

Lastly general checks for reviews correctly being submitted and for the application in general.