### PR TITLE
set max length for year input

### DIFF
--- a/templates/addSession.html
+++ b/templates/addSession.html
@@ -8,7 +8,7 @@
         {% endif %}
         <form id="add-session" action="{{ url_for('profDashboard', session_id=session_id) }}" method=POST>
             <p class="heading">Start Term: <input type=text required='required' name=start_term></p>
-            <p class="heading">Start Year: <input type=text required='required' name=start_year></p>
+            <p class="heading">Start Year: <input type=text required='required' name=start_year maxlength="4"></p>
             <p class="heading">Assign to professor:</p>
             <select class="selected_professor" name="professor_id">
                 {% for i in prof_list %}


### PR DESCRIPTION
addresses a bug I encountered when a year is set at an absurd length. Hopefully it's fine to limit the year input to the next 8000 years